### PR TITLE
github actions clone current branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,10 +9,12 @@ on:
 env:
   # home directory of user in obcpp docker image
   HOME_DIR: /home/tuas
+  # https://stackoverflow.com/a/71158878
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
 
 jobs:
   test:
-    name: clang-tidy 
+    name: cpplint 
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/tritonuas/obcpp:main
@@ -21,10 +23,11 @@ jobs:
         run: mkdir -p "$HOME_DIR/obcpp"
 
       - name: Clone Repo
-        run: git clone https://oauth2:${{secrets.GITHUB_TOKEN}}@github.com/tritonuas/obcpp.git /home/tuas/obcpp
+        run: git clone --branch $BRANCH_NAME https://oauth2:${{secrets.GITHUB_TOKEN}}@github.com/tritonuas/obcpp.git $HOME_DIR/obcpp
 
-      - name: Set up Cmake
+      - name: Set up CMake
+        # uses ${CMAKE_PREFIX_PATH} set in Dockerfile env
         run: cd "$HOME_DIR/obcpp" && mkdir build && cd build && sudo cmake -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" ..
 
-      - name: Run clang-tidy
+      - name: Run cpplint
         run: cd "$HOME_DIR/obcpp/build" && sudo make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
 env:
   # home directory of user in obcpp docker image
   HOME_DIR: /home/tuas
+  # https://stackoverflow.com/a/71158878
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
 
 jobs:
   test:
@@ -21,9 +23,10 @@ jobs:
         run: mkdir -p "$HOME_DIR/obcpp"
 
       - name: Clone Repo
-        run: git clone https://oauth2:${{secrets.GITHUB_TOKEN}}@github.com/tritonuas/obcpp.git /home/tuas/obcpp
+        run: git clone --branch $BRANCH_NAME https://oauth2:${{secrets.GITHUB_TOKEN}}@github.com/tritonuas/obcpp.git $HOME_DIR/obcpp
 
-      - name: Set up Cmake
+      - name: Set up CMake
+        # uses ${CMAKE_PREFIX_PATH} set in Dockerfile env
         run: cd "$HOME_DIR/obcpp" && mkdir build && cd build && sudo cmake -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}" ..
 
       - name: Run Tests


### PR DESCRIPTION
previously lint/test actions were only cloning the main branch, leading to actions not reflecting the current state of a branch.