### PR TITLE
Conditionally Run Container Build Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          src:
+            - '.devcontainer/**'
 
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1


### PR DESCRIPTION
We should not build the container on every push to main.

~~It is not possible to have an `AND` condition for the action trigger (can't do `on:` `push: branch: main` and `push: paths: - '.devcontainer/**'`). Thus, now in order to rebuild the container, you have to create a release of this repo.~~

Have changed approach based on feedback. Now uses the approach from here:
https://how.wtf/run-workflow-step-or-job-based-on-file-changes-github-actions.html
