### PR TITLE
QT_QPA_PLATFORM env var for headless mode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,6 +2,8 @@ FROM amd64/ubuntu:22.04
 
 ARG USERNAME=tuas USER_UID=1000 USER_GID=1000 DEBIAN_FRONTEND=noninteractive
 
+ENV QT_QPA_PLATFORM="vnc" # Needed to spawn up a GUI in headless mode for matplotplus to work
+
 # Create a non-root user
 RUN groupadd -f --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME


### PR DESCRIPTION
set QT_QPA_PLATFORM to "vnc" so that matplotplus(which uses gnuplot under the hood) can connect to a display server (headless in this case). otherwise you cannot save images with matplotplus.