### PR TITLE
tell vscode to use build/compile_commands.json for intellisense

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ _deps/
 Testing/
 imgs/
 
-.vscode
+.vscode/*
+!.vscode/c_cpp_properties.json
 
 libcore_library.dylib
 .DS_Store

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,9 @@
+{
+    "configurations": [
+        {
+            "name": "CMake",
+            "compileCommands": "${workspaceFolder}/build/compile_commands.json"
+        }
+    ],
+    "version": 4
+}


### PR DESCRIPTION
Should help those using vscode C++ extension to have working autocomplete/intellisense. 

Uses the `compile_commands.json` file generated by CMake here: https://github.com/tritonuas/obcpp/blob/main/CMakeLists.txt#L25

Read up more on it: https://clangd.llvm.org/design/compile-commands https://code.visualstudio.com/docs/cpp/c-cpp-properties-schema-reference