### PR TITLE
remove conflicting imagemagick dep

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,7 +46,6 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,sharing=locked \
                            # needed for matplotplus
                            gnuplot \ 
                            # imagemagick with c++ dependency
-                           graphicsmagick-libmagick-dev-compat \
                            libmagick++-dev
 
 RUN apt-add-repository universe


### PR DESCRIPTION
 #7 11.79 The following packages have unmet dependencies:
#7 11.89  graphicsmagick-libmagick-dev-compat : Conflicts: libmagick++-dev
#7 11.89                                        Conflicts: libmagickcore-dev
#7 11.90 E: Unable to correct problems, you have held broken packages.