### PR TITLE
trying to push to full image tag

### DIFF
--- a/.github/workflows/docker-x86.yml
+++ b/.github/workflows/docker-x86.yml
@@ -55,6 +55,6 @@ jobs:
           file: ${{ env.DOCKERFILE_PATH }} 
           context: .
           push: true
-          tags: ${{ env.TAG }} 
+          tags: ghcr.io/${{ github.repository }}:${{ env.TAG }} 
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
docker push action for x86 image has been broken for the past two weeks after this action failed: https://github.com/tritonuas/obcpp/actions/runs/8638682448. This was throwing a crptic error saying "buildx failed with: ERROR: unauthorized: access token has insufficient scopes". This didn't seem like a token issue since the docker login step succeeded and the push step has permissions to write to GitHub packages. This commit attempts to push an the image to the full tag "ghcr.io/tritonuas/obcpp:x86" instead of just "x86"