### PR TITLE
Fix unit tests using GCS Handler Macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,31 +118,11 @@ add_subdirectory(src)
 # =============================
 
 # =============================
-# Integration tests
+# Tests
 
-add_subdirectory(tests/integration)
-
-# cuda_check
-add_executable(cuda_check ${SOURCES} tests/integration/cuda_check.cpp)
-target_add_torch(cuda_check)
-target_add_json(cuda_check)
-target_add_httplib(cuda_check)
-target_add_mavsdk(cuda_check)
-target_add_matplot(cuda_check)
-target_add_protobuf(cuda_check)
-target_add_opencv(cuda_check)
-target_add_loguru(cuda_check)
-# for some reason calling target_add_imagemagick here conflicts with, so we are including/linking without the function call
-# target_add_imagemagick(cuda_check)
-target_include_directories(cuda_check PRIVATE ${ImageMagick_INCLUDE_DIRS})
-target_link_libraries(cuda_check PRIVATE -Wl,--copy-dt-needed-entries ${ImageMagick_LIBRARIES})
-
-# =============================
-
-# =============================
-# Unit tests
-add_subdirectory(tests/unit)
 add_subdirectory(${DEPS_DIRECTORY}/google-test)
+add_subdirectory(tests)
+
 # =============================
 
 # =============================

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+# so everything in unit and integration tests can include header files in this directory
+include_directories(util)
+
+add_compile_definitions(CONFIG_DIRECTORY="${PROJECT_SOURCE_DIR}/configs")
+
+add_subdirectory(integration)
+
+add_subdirectory(unit)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -283,3 +283,18 @@ target_add_matplot(camera_mock)
 target_add_loguru(camera_mock)
 target_include_directories(camera_mock PRIVATE ${ImageMagick_INCLUDE_DIRS})
 target_link_libraries(camera_mock PRIVATE -Wl,--copy-dt-needed-entries ${ImageMagick_LIBRARIES})
+
+# cuda_check
+add_executable(cuda_check ${SOURCES} cuda_check.cpp)
+target_add_torch(cuda_check)
+target_add_json(cuda_check)
+target_add_httplib(cuda_check)
+target_add_mavsdk(cuda_check)
+target_add_matplot(cuda_check)
+target_add_protobuf(cuda_check)
+target_add_opencv(cuda_check)
+target_add_loguru(cuda_check)
+# for some reason calling target_add_imagemagick here conflicts with, so we are including/linking without the function call
+# target_add_imagemagick(cuda_check)
+target_include_directories(cuda_check PRIVATE ${ImageMagick_INCLUDE_DIRS})
+target_link_libraries(cuda_check PRIVATE -Wl,--copy-dt-needed-entries ${ImageMagick_LIBRARIES})

--- a/tests/unit/gcs_server_test.cpp
+++ b/tests/unit/gcs_server_test.cpp
@@ -20,24 +20,7 @@
 #include "ticks/mav_upload.hpp"
 #include "ticks/tick.hpp"
 
-// TODO: figure out why it is seg faulting when running these unit tests and fix it...
-// I think it's something to do with DECLARE_HANDLER_PARAMS not being up to
-// date with updated command line arguments, but after trying to fix that it was
-// stil seg faulting and I want a green checkmark...
-
-/*
-#define DECLARE_HANDLER_PARAMS(STATE, REQ, RESP) \
-    int argc = 2; \
-    char path1[] = "bin/obcpp"; \
-    char path2[] = "../configs"; \
-    char path3[] = "dev"; \
-    char path4[] = "stickbug"; \
-    char path5[] = "sitl"; \
-    char *paths[] = {path1, path2, path3, path4, path5}; \
-    char **paths_ptr = paths; \
-    std::shared_ptr<MissionState> STATE = std::make_shared<MissionState>(OBCConfig(argc, paths_ptr)); \
-    httplib::Request REQ; \
-    httplib::Response RESP 
+#include "handler_params.hpp"
 
 // Might have to change this later on if we preload
 // mission from file
@@ -215,4 +198,3 @@ TEST(GCSServerTest, SetupStateTransitions) {
     // todo: figure out way to mock the mav connection
     // so we can validate the path and mock mission upload
 }
-*/

--- a/tests/util/handler_params.hpp
+++ b/tests/util/handler_params.hpp
@@ -1,0 +1,16 @@
+#ifndef TESTS_HELPERS_HPP_
+#define TESTS_HELPERS_HPP_
+
+#define DECLARE_HANDLER_PARAMS(STATE, REQ, RESP) \
+    int argc = 5; \
+    char argv0[] = "bin/obcpp"; \
+    char argv1[] = CONFIG_DIRECTORY; \
+    char argv2[] = "dev"; \
+    char argv3[] = "stickbug"; \
+    char argv4[] = "sitl"; \
+    char *argv[] = {argv0, argv1, argv2, argv3, argv4, nullptr }; \
+    std::shared_ptr<MissionState> STATE = std::make_shared<MissionState>(OBCConfig(argc, argv)); \
+    httplib::Request REQ; \
+    httplib::Response RESP 
+
+#endif  // TESTS_HELPERS_HPP_


### PR DESCRIPTION
Sets up some shared infrastructure for all of the unit tests that want to mock GCS handler requests so they can use the same macro instead of redefining it across a ton of different files.

Fixes the macro which has been breaking ever since I updated how the OBC configuration setup works.

Right now this only fixes it for the gcs_server_test unit test. Other tests should be able to run if they remove their own declaration of the macro and include the one in the common header file.

Someone else should try and apply this fix to all of the other tests that use the macro. Feel free to add onto this PR or make another one.

I can explain what is going on easier in a voice call if interested.