### PR TITLE
Add refueling tick and integrate it into the tick architecture

### DIFF
--- a/include/core/mission_state.hpp
+++ b/include/core/mission_state.hpp
@@ -103,8 +103,10 @@ class MissionState {
     std::shared_ptr<CameraInterface> getCamera();
     void setCamera(std::shared_ptr<CameraInterface> camera);
 
-    MissionParameters mission_params;  // has its own mutex
+    bool getIsGrounded() const;
+    void setIsGrounded(bool isGrounded);
 
+    MissionParameters mission_params;  // has its own mutex
 
     OBCConfig config;
 
@@ -137,7 +139,7 @@ class MissionState {
     // Gives an index into cv_detected_targets, and specifies that that bottle is matched
     // with the detected_target specified by the index
     std::array<size_t, NUM_AIRDROP_BOTTLES> cv_matches;
-
+    bool isGrounded;
 
     void _setTick(Tick* newTick);  // does not acquire the tick_mut
 };

--- a/include/ticks/ids.hpp
+++ b/include/ticks/ids.hpp
@@ -19,10 +19,12 @@ enum class TickID {
     MissionDone,
     ActiveTakeoff,
     WaitForTakeoff,
+    Refueling,
 };
 
 #define _SET_TICK_ID_MAPPING(id) \
-    case TickID::id: return #id
+    case TickID::id:             \
+        return #id
 
 constexpr const char* TICK_ID_TO_STR(TickID id) {
     switch (id) {
@@ -41,7 +43,9 @@ constexpr const char* TICK_ID_TO_STR(TickID id) {
         _SET_TICK_ID_MAPPING(MissionDone);
         _SET_TICK_ID_MAPPING(ActiveTakeoff);
         _SET_TICK_ID_MAPPING(WaitForTakeoff);
-        default: return "Unknown TickID";
+        _SET_TICK_ID_MAPPING(Refueling);
+        default:
+            return "Unknown TickID";
     }
 }
 

--- a/include/ticks/manual_landing.hpp
+++ b/include/ticks/manual_landing.hpp
@@ -1,8 +1,8 @@
 #ifndef INCLUDE_TICKS_MANUAL_LANDING_HPP_
 #define INCLUDE_TICKS_MANUAL_LANDING_HPP_
 
-#include <memory>
 #include <chrono>
+#include <memory>
 
 #include "ticks/tick.hpp"
 
@@ -11,11 +11,14 @@
  */
 class ManualLandingTick : public Tick {
  public:
-    explicit ManualLandingTick(std::shared_ptr<MissionState> state);
+    explicit ManualLandingTick(std::shared_ptr<MissionState> state, Tick* next_tick);
 
     std::chrono::milliseconds getWait() const override;
 
     Tick* tick() override;
+
+ private:
+    Tick* next_tick;
 };
 
 #endif  // INCLUDE_TICKS_MANUAL_LANDING_HPP_

--- a/include/ticks/refueling.hpp
+++ b/include/ticks/refueling.hpp
@@ -1,0 +1,21 @@
+#ifndef INCLUDE_TICKS_REFUELING_HPP_
+#define INCLUDE_TICKS_REFUELING_HPP_
+
+#include <chrono>
+#include <memory>
+
+#include "ticks/tick.hpp"
+
+/*
+ * Wait for the refueling process to finish.
+ */
+class RefuelingTick : public Tick {
+ public:
+    explicit RefuelingTick(std::shared_ptr<MissionState> state);
+
+    std::chrono::milliseconds getWait() const override;
+
+    Tick* tick() override;
+};
+
+#endif  // INCLUDE_TICKS_REFUELING_HPP_

--- a/include/utilities/constants.hpp
+++ b/include/utilities/constants.hpp
@@ -77,6 +77,7 @@ const std::chrono::milliseconds AUTO_LANDING_TICK_WAIT = std::chrono::millisecon
 const std::chrono::milliseconds MISSION_DONE_TICK_WAIT = std::chrono::milliseconds(100);
 const std::chrono::milliseconds ACTIVE_TAKEOFF_TICK_WAIT = std::chrono::milliseconds(100);
 const std::chrono::milliseconds WAIT_FOR_TAKEOFF_TICK_WAIT = std::chrono::milliseconds(100);
+const std::chrono::milliseconds REFUELING_TICK_WAIT = std::chrono::milliseconds(100);
 
 const double EARTH_RADIUS_METERS = 6378137.0;
 

--- a/src/core/mission_state.cpp
+++ b/src/core/mission_state.cpp
@@ -140,3 +140,11 @@ std::shared_ptr<CameraInterface> MissionState::getCamera() {
 void MissionState::setCamera(std::shared_ptr<CameraInterface> camera) {
     this->camera = camera;
 }
+
+bool MissionState::getIsGrounded() const {
+    return this->is_grounded;
+}
+
+void MissionState::setIsGrounded(bool is_grounded) {
+    this->is_grounded = is_grounded;
+}

--- a/src/ticks/manual_landing.cpp
+++ b/src/ticks/manual_landing.cpp
@@ -5,13 +5,13 @@
 #include "ticks/ids.hpp"
 #include "utilities/constants.hpp"
 
-ManualLandingTick::ManualLandingTick(std::shared_ptr<MissionState> state)
-    :Tick(state, TickID::ManualLanding) {}
+ManualLandingTick::ManualLandingTick(std::shared_ptr<MissionState> state, Tick* next_tick)
+    : Tick(state, TickID::ManualLanding), next_tick(next_tick) {}
 
-std::chrono::milliseconds ManualLandingTick::getWait() const {
-    return MANUAL_LANDING_TICK_WAIT;
-}
+std::chrono::milliseconds ManualLandingTick::getWait() const { return MANUAL_LANDING_TICK_WAIT; }
 
 Tick* ManualLandingTick::tick() {
-    return nullptr;
+    if (!state.get()->getMav()->isArmed()) {
+        return next_tick;
+    }
 }

--- a/src/ticks/refueling.cpp
+++ b/src/ticks/refueling.cpp
@@ -1,0 +1,18 @@
+#include "ticks/refueling.hpp"
+
+#include <memory>
+
+#include "ticks/ids.hpp"
+#include "ticks/mav_upload.hpp"
+#include "utilities/constants.hpp"
+
+RefuelingTick::RefuelingTick(std::shared_ptr<MissionState> state)
+    : Tick(state, TickID::Refueling) {}
+
+std::chrono::milliseconds RefuelingTick::getWait() const { return REFUELING_TICK_WAIT; }
+
+Tick* RefuelingTick::tick() {
+    if (state.get()->getMav()->isArmed()) {
+        return new MavUploadTick(state, new WaitForTakeoffTick(state), state->getInitPath(), false);
+    }
+}


### PR DESCRIPTION
The plane only changes to the refueling tick when there have been 2 airdrops. It changes from airdrop approach tick -> manual landing tick -> refueling tick. The refueling tick waits for the plane to be rearmed to change to the mav upload tick which uploads the initial path and then waits for takeoff.

Closes: #242 #241 #235 #240