### PR TITLE
Add config for generating deviations in mission path

### DIFF
--- a/configs/dev.json
+++ b/configs/dev.json
@@ -25,7 +25,8 @@
             "rewire_radius": 256.0,
             "optimize": true,
             "point_fetch_method": "nearest",
-            "allowed_to_skip_waypoints": false
+            "allowed_to_skip_waypoints": false,
+            "generate_deviation": false
         },
         "coverage": {
             "altitude_m": 30.0,

--- a/include/core/mission_parameters.hpp
+++ b/include/core/mission_parameters.hpp
@@ -29,6 +29,7 @@ class MissionParameters {
 
     Polygon getFlightBoundary();
     Polygon getAirdropBoundary();
+    Polygon getMappingBoundary();
     Polyline getWaypoints();
     std::vector<Bottle> getAirdropBottles();
 
@@ -50,6 +51,7 @@ class MissionParameters {
 
     Polygon flightBoundary;
     Polygon airdropBoundary;
+    Polygon mappingBoundary;
     Polyline waypoints;
     std::vector<Bottle> bottles;
 

--- a/include/utilities/obc_config.hpp
+++ b/include/utilities/obc_config.hpp
@@ -1,12 +1,13 @@
 #ifndef INCLUDE_UTILITIES_OBC_CONFIG_HPP_
 #define INCLUDE_UTILITIES_OBC_CONFIG_HPP_
 
-#include <variant>
-#include <string>
-#include <utility>
-#include <unordered_set>
-#include <unordered_map>
 #include <initializer_list>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <variant>
+
 #include "udp_squared/internal/enum.h"
 #include "utilities/constants.hpp"
 #include "utilities/datatypes.hpp"
@@ -42,15 +43,14 @@ struct CVConfig {
 };
 
 namespace PointFetchMethod {
-    enum class Enum {
-        NONE,    // check RRT against every node (path optimal, but incredibly slow)
-        RANDOM,  // check ~k randomly sampled nodes from the tree.
-        NEAREST  // check ~$p$ nodes closest to the sampled node (best performance/time ratio from
-                // rudimentary testing)
-    };
-    CONFIG_VARIANT_MAPPING_T(Enum) MAPPINGS = {
-        {"none", Enum::NONE}, {"random", Enum::RANDOM}, {"nearest", Enum::NEAREST}
-    };
+enum class Enum {
+    NONE,    // check RRT against every node (path optimal, but incredibly slow)
+    RANDOM,  // check ~k randomly sampled nodes from the tree.
+    NEAREST  // check ~$p$ nodes closest to the sampled node (best performance/time ratio from
+             // rudimentary testing)
+};
+CONFIG_VARIANT_MAPPING_T(Enum)
+MAPPINGS = {{"none", Enum::NONE}, {"random", Enum::RANDOM}, {"nearest", Enum::NEAREST}};
 };  // namespace PointFetchMethod
 
 struct DubinsConfig {
@@ -65,16 +65,12 @@ struct RRTConfig {
     PointFetchMethod::Enum point_fetch_method;
     bool allowed_to_skip_waypoints;  // if true, will skip waypoints if it can not connect after 1
                                      // RRT iteration
+    bool generate_deviations;        // if true, will generate deviations for the path
 };
 
 namespace AirdropCoverageMethod {
-    enum class Enum {
-        HOVER,
-        FORWARD
-    };
-    CONFIG_VARIANT_MAPPING_T(Enum) MAPPINGS = {
-        {"hover", Enum::HOVER}, {"forward", Enum::FORWARD}
-    };
+enum class Enum { HOVER, FORWARD };
+CONFIG_VARIANT_MAPPING_T(Enum) MAPPINGS = {{"hover", Enum::HOVER}, {"forward", Enum::FORWARD}};
 };  // namespace AirdropCoverageMethod
 
 struct AirdropCoverageConfig {
@@ -93,14 +89,9 @@ struct AirdropCoverageConfig {
 };
 
 namespace AirdropDropMethod {
-    enum class Enum {
-        GUIDED,
-        UNGUIDED
-    };
-    CONFIG_VARIANT_MAPPING_T(Enum) MAPPINGS = {
-        {"guided", Enum::GUIDED}, {"unguided", Enum::UNGUIDED}
-    };
-};
+enum class Enum { GUIDED, UNGUIDED };
+CONFIG_VARIANT_MAPPING_T(Enum) MAPPINGS = {{"guided", Enum::GUIDED}, {"unguided", Enum::UNGUIDED}};
+};  // namespace AirdropDropMethod
 
 struct AirdropApproachConfig {
     AirdropDropMethod::Enum drop_method;

--- a/src/utilities/obc_config.cpp
+++ b/src/utilities/obc_config.cpp
@@ -1,9 +1,9 @@
 #include "utilities/obc_config.hpp"
 
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 #include <string>
-#include <iostream>
 
 #include "nlohmann/json.hpp"
 #include "udp_squared/internal/enum.h"
@@ -16,9 +16,15 @@ OBCConfig::OBCConfig(int argc, char* argv[]) {
     // If config-json name is passed in
     if (argc != 5) {
         LOG_F(ERROR, "INVALID COMMAND LINE ARGUMENTS");
-        LOG_F(ERROR, "Expected use: ./obcpp [config_dir] [rel_config_path] [plane_name] [flight_type]");  // NOLINT
-        LOG_F(ERROR, "Example 1 (Test Flight with Jetson): bin/obcpp ../configs jetson stickbug test-flight");  // NOLINT
-        LOG_F(ERROR, "Example 2 (Local Testing with SITL): bin/obcpp ../configs dev stickbug sitl");  // NOLINT
+        LOG_F(
+            ERROR,
+            "Expected use: ./obcpp [config_dir] [rel_config_path] [plane_name] [flight_type]");  // NOLINT
+        LOG_F(ERROR,
+              "Example 1 (Test Flight with Jetson): bin/obcpp ../configs jetson stickbug "
+              "test-flight");  // NOLINT
+        LOG_F(
+            ERROR,
+            "Example 2 (Local Testing with SITL): bin/obcpp ../configs dev stickbug sitl");  // NOLINT
         LOG_F(ERROR, "For more help, check the README");
         LOG_F(FATAL, "ABORTING...");
     }
@@ -55,6 +61,7 @@ OBCConfig::OBCConfig(int argc, char* argv[]) {
     SET_CONFIG_OPT(pathing, rrt, iterations_per_waypoint);
     SET_CONFIG_OPT(pathing, rrt, rewire_radius);
     SET_CONFIG_OPT(pathing, rrt, optimize);
+    SET_CONFIG_OPT(pathing, rrt, generate_deviations);
 
     SET_CONFIG_OPT_VARIANT(PointFetchMethod, pathing, rrt, point_fetch_method);
 
@@ -96,13 +103,13 @@ OBCConfig::OBCConfig(int argc, char* argv[]) {
     std::ifstream common_params_stream(common_params_path);
     if (!common_params_stream.is_open()) {
         LOG_F(FATAL, "Invalid path to common params file: %s (Does this file exist?)",
-            common_params_path.c_str());
+              common_params_path.c_str());
     }
     std::string specific_params_path = params_dir / flight_type_file;
     std::ifstream specific_params_stream(specific_params_path);
     if (!specific_params_stream.is_open()) {
         LOG_F(FATAL, "Invalid path to specific params file: %s (Does this file exist?)",
-            specific_params_path.c_str());
+              specific_params_path.c_str());
     }
 
     auto common_params = nlohmann::json::parse(common_params_stream, nullptr, true, true);


### PR DESCRIPTION
- Add a config in RRT configs to turn off deviation generation(which generates an additional way point for the purpose of mapping) because mapping bounds has not yet been set
- Set up mapping bounds on obc side in mission parameters