### PR TITLE
Rewire Ticks

### DIFF
--- a/src/ticks/airdrop_approach.cpp
+++ b/src/ticks/airdrop_approach.cpp
@@ -82,11 +82,8 @@ Tick* AirdropApproachTick::tick() {
     if (state->getMav()->isMissionFinished()) {
         if (state->getDroppedAirdrops().size() >= NUM_AIRDROPS) {
             return new ManualLandingTick(state, nullptr);
-        // } else if (state->getDroppedAirdrops().size() % state->config.takeoff.payload_size == 0) {
-        //     return new ManualLandingTick(state, new RefuelingTick(state));
         } else {
-            return new MavUploadTick(state, new FlyWaypointsTick(state, new AirdropPrepTick(state)),
-                                     state->getAirdropPath(), false);
+            return new AirdropPrepTick(state);
         }
     }
 


### PR DESCRIPTION
closes #306 

# Description

Rewires ticks to current competition specification. 

- Remove switching to refueling
- Remove waypoint runs between airdrops

# Testing

SITL tested 2 times on NixOS | runway right | 4 waypoints.

## Other thoughts

- Mapping needs to pull from same dir as cv (decide on compression)