### PR TITLE
Fix/waypoint mission start

### DIFF
--- a/src/pathing/static.cpp
+++ b/src/pathing/static.cpp
@@ -635,9 +635,7 @@ MissionPath generateInitialPath(std::shared_ptr<MissionState> state) {
     std::vector<GPSCoord> output_coords;
     output_coords.push_back(
         state->getCartesianConverter()->toLatLng(state->mission_params.getWaypoints().front()));
-    output_coords.push_back(
-        state->getCartesianConverter()->toLatLng(state->mission_params.getWaypoints().front()));
-    for (const XYZCoord &wpt : goals) {
+    for (const XYZCoord &wpt : path) {
         output_coords.push_back(state->getCartesianConverter()->toLatLng(wpt));
     }
 


### PR DESCRIPTION
closes #258 

# Description

1. Uses RRT for waypoint pathing again (instead of just the waypoints)
2. Changes the point upload algorithm to repeat the first point. For whatever reason, the SITL never flew towards the first point unless it was duplicated (I think hover still has the same issue).

# Mav References

https://mavsdk.mavlink.io/main/en/cpp/api_reference/structmavsdk_1_1_mission_1_1_mission_item.html#mavsdk-mission-missionitem-struct-reference

https://mavlink.io/en/messages/common.html#MISSION_ITEM_INT