### PR TITLE
chore: disable docker build on CI

### DIFF
--- a/.github/workflows/docker-arm.yml
+++ b/.github/workflows/docker-arm.yml
@@ -3,7 +3,7 @@ name: Push ARM Docker Image
 on:
   push:
     branches:
-      - main 
+      # - main 
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-jetson.yml
+++ b/.github/workflows/docker-jetson.yml
@@ -3,7 +3,7 @@ name: Push Jetson Docker Image
 on:
   push:
     branches:
-      - main 
+      # - main 
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-x86.yml
+++ b/.github/workflows/docker-x86.yml
@@ -3,7 +3,7 @@ name: Push x86 Docker Image
 on:
   push:
     branches:
-      - main
+      # - main
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Our docker builds always timeout the GH Actions. Until we shrink the size of our containers, we should disable the docker build.